### PR TITLE
feat: cli

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "root",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: run,
+}
+
+func init() {
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func run(cmd *cobra.Command, args []string) {
+	fmt.Println("Hello World", cmd.Flag("toggle").Value.String())
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,9 @@
+module github.com/book000/templates/cli
+
+go 1.19
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/book000/templates/cli/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,6 @@
   "ignorePresets": [
     ":prHourlyLimit2"
   ],
-  "reviewers": [
-    "book000"
-  ],
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "automerge": true,

--- a/templates.code-workspace
+++ b/templates.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": "cli"
+		},
+		{
+			"path": "dockerfiles"
+		},
+		{
+			"path": "workflows"
+		},
+		{
+			"path": "."
+		}
+	]
+}


### PR DESCRIPTION
```
book000-templates cli

$ book000-templates

| --type / -t
> book000/templatesからテンプレートディレクトリを取得

>> テンプレートの種別を選択させる

| --file / -f
> 選択したディレクトリをもとに、book000/templatesからファイル群を取得

>> テンプレートを選択させる

> テンプレートのオプションを取得
- workflows/options.json とかつくるか？

>> テンプレートのオプションごとに入力させる

>> 出力先を指定（デフォルト値を持たせる）

---

- [ ] オプションとかのテスト
```