### PR TITLE
fix: arm64プラットフォーム用のビルド環境を追加

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -120,7 +120,8 @@ jobs:
   # Dockerイメージをビルドする
   build:
     name: Docker build (${{ matrix.target.packageName }}, ${{ matrix.platform }})
-    runs-on: ubuntu-latest
+    # matrix.platform が linux/arm64 の場合は ubuntu-24.04-arm を使う。それ以外の場合は ubuntu-latest を使う
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     needs: calc-version
 
     strategy:


### PR DESCRIPTION
- linux/arm64の場合はubuntu-24.04-armを使用
- それ以外はubuntu-latestを使用