### PR TITLE
fix: shellcheck エラーの修正 ($GITHUB_OUTPUT の二重クォートと parameter expansion)

### DIFF
--- a/.github/workflows/reusable-add-reviewer.yml
+++ b/.github/workflows/reusable-add-reviewer.yml
@@ -27,7 +27,7 @@ jobs:
           # Use printf to safely handle the input without shell injection
           ACTORS=$(printf '%s' "${{ inputs.actors }}" | jq -R -c 'split(",") | map(select(length > 0) | ltrimstr(" ") | rtrimstr(" "))')
           echo "actors: $ACTORS"
-          echo "is-need-add-reviewer=$(printf '%s' "$ACTORS" | jq -r --arg actor "${{ github.actor }}" '. | contains([$actor]) | not')" >> ""$GITHUB_OUTPUT""
+          echo "is-need-add-reviewer=$(printf '%s' "$ACTORS" | jq -r --arg actor "${{ github.actor }}" '. | contains([$actor]) | not')" >> "$GITHUB_OUTPUT"
 
       - name: Add reviewer
         uses: actions/github-script@v9

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -433,11 +433,11 @@ jobs:
       - name: 📦 Create zip
         id: create-zip
         run: |
-          REPO="${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}"
-          ZIP_FILENAME=${REPO}_${{ needs.calc-version.outputs.tag }}.zip
-          ZIP_PATH=$(pwd)/output/${ZIP_FILENAME}
+          REPO="${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}/"}"
+          ZIP_FILENAME="${REPO}_${{ needs.calc-version.outputs.tag }}.zip"
+          ZIP_PATH="$(pwd)/output/${ZIP_FILENAME}"
           cd output
-          zip -r ${ZIP_PATH} ./*
+          zip -r "${ZIP_PATH}" ./*
           echo "zip-path=${ZIP_PATH}" >> "$GITHUB_OUTPUT"
           echo "zip-filename=${ZIP_FILENAME}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -397,11 +397,11 @@ jobs:
         id: check-package-manager
         run: |
           if [ -f "yarn.lock" ]; then
-            echo "package-manager=yarn" >> ""$GITHUB_OUTPUT""
+            echo "package-manager=yarn" >> "$GITHUB_OUTPUT"
           elif [ -f "pnpm-lock.yaml" ]; then
-            echo "package-manager=pnpm" >> ""$GITHUB_OUTPUT""
+            echo "package-manager=pnpm" >> "$GITHUB_OUTPUT"
           else
-            echo "package-manager=npm" >> ""$GITHUB_OUTPUT""
+            echo "package-manager=npm" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup pnpm
@@ -433,7 +433,7 @@ jobs:
       - name: 📦 Create zip
         id: create-zip
         run: |
-          REPO="${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}/"}"
+          REPO="${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}"
           ZIP_FILENAME=${REPO}_${{ needs.calc-version.outputs.tag }}.zip
           ZIP_PATH=$(pwd)/output/${ZIP_FILENAME}
           cd output

--- a/.github/workflows/reusable-nodejs-ci-pnpm.yml
+++ b/.github/workflows/reusable-nodejs-ci-pnpm.yml
@@ -42,9 +42,9 @@ jobs:
         run: |
           # Use printf to safely handle the input without shell injection
           DIRECTORYS=$(printf '%s' "${{ inputs.directorys }}" | jq -R -c 'split(",") | map(select(length > 0) | ltrimstr(" ") | rtrimstr(" "))')
-          echo "directorys=$DIRECTORYS" >> ""$GITHUB_OUTPUT""
+          echo "directorys=$DIRECTORYS" >> "$GITHUB_OUTPUT"
           DISABLED_JOBS=$(printf '%s' "${{ inputs.disabled-jobs }}" | jq -R -c 'split(",") | map(select(length > 0) | ltrimstr(" ") | rtrimstr(" "))' | sed -e "s/\"/\\\\\"/g")
-          echo "disabled-jobs=$DISABLED_JOBS" >> ""$GITHUB_OUTPUT""
+          echo "disabled-jobs=$DISABLED_JOBS" >> "$GITHUB_OUTPUT"
 
   node-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-nodejs-ci.yml
+++ b/.github/workflows/reusable-nodejs-ci.yml
@@ -100,20 +100,24 @@ jobs:
           echo "lint: $lint"
           echo "test: $test"
 
-          echo "compile=$compile" >> "$GITHUB_OUTPUT"
-          echo "build=$build" >> "$GITHUB_OUTPUT"
-          echo "generate=$generate" >> "$GITHUB_OUTPUT"
-          echo "package=$package" >> "$GITHUB_OUTPUT"
-          echo "lint=$lint" >> "$GITHUB_OUTPUT"
-          echo "test=$test" >> "$GITHUB_OUTPUT"
+          {
+            echo "compile=$compile"
+            echo "build=$build"
+            echo "generate=$generate"
+            echo "package=$package"
+            echo "lint=$lint"
+            echo "test=$test"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "disabled-compile=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["compile"])')" >> "$GITHUB_OUTPUT"
-          echo "disabled-build=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["build"])')" >> "$GITHUB_OUTPUT"
-          echo "disabled-generate=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["generate"])')" >> "$GITHUB_OUTPUT"
-          echo "disabled-package=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["package"])')" >> "$GITHUB_OUTPUT"
-          echo "disabled-lint=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["lint"])')" >> "$GITHUB_OUTPUT"
-          echo "disabled-test=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["test"])')" >> "$GITHUB_OUTPUT"
-          echo "disabled-depcheck=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["depcheck"])')" >> "$GITHUB_OUTPUT"
+          {
+            echo "disabled-compile=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["compile"])')"
+            echo "disabled-build=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["build"])')"
+            echo "disabled-generate=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["generate"])')"
+            echo "disabled-package=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["package"])')"
+            echo "disabled-lint=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["lint"])')"
+            echo "disabled-test=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["test"])')"
+            echo "disabled-depcheck=$(echo ${{ needs.setup.outputs.disabled-jobs }} | jq -r '. | contains(["depcheck"])')"
+          } >> "$GITHUB_OUTPUT"
 
       - name: 📂 Cache node_modules
         uses: actions/cache@v5

--- a/.github/workflows/reusable-nodejs-ci.yml
+++ b/.github/workflows/reusable-nodejs-ci.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           # Use printf to safely handle the input without shell injection
           DIRECTORYS=$(printf '%s' "${{ inputs.directorys }}" | jq -R -c 'split(",") | map(select(length > 0) | ltrimstr(" ") | rtrimstr(" "))')
-          echo "directorys=$DIRECTORYS" >> ""$GITHUB_OUTPUT""
+          echo "directorys=$DIRECTORYS" >> "$GITHUB_OUTPUT"
           DISABLED_JOBS=$(printf '%s' "${{ inputs.disabled-jobs }}" | jq -R -c 'split(",") | map(select(length > 0) | ltrimstr(" ") | rtrimstr(" "))' | sed -e "s/\"/\\\\\"/g")
-          echo "disabled-jobs=$DISABLED_JOBS" >> ""$GITHUB_OUTPUT""
+          echo "disabled-jobs=$DISABLED_JOBS" >> "$GITHUB_OUTPUT"
 
   node-ci:
     runs-on: ubuntu-latest
@@ -169,7 +169,7 @@ jobs:
         run: |
           IS_DIRECTORY=$(test -d dist && echo true || echo false)
           IS_SYMLINK=$(test -L dist && echo true || echo false)
-          echo "exists=$(test "$IS_DIRECTORY" = true && test "$IS_SYMLINK" = false && echo true || echo false)" >> ""$GITHUB_OUTPUT""
+          echo "exists=$(test "$IS_DIRECTORY" = true && test "$IS_SYMLINK" = false && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: 📦 Upload dist artifact
         if: steps.check-dist.outputs.exists == 'true'
@@ -183,7 +183,7 @@ jobs:
         run: |
           IS_DIRECTORY=$(test -d output && echo true || echo false)
           IS_SYMLINK=$(test -L output && echo true || echo false)
-          echo "exists=$(test "$IS_DIRECTORY" = true && test "$IS_SYMLINK" = false && echo true || echo false)" >> ""$GITHUB_OUTPUT""
+          echo "exists=$(test "$IS_DIRECTORY" = true && test "$IS_SYMLINK" = false && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: 📦 Upload output artifact
         if: steps.check-output.outputs.exists == 'true'


### PR DESCRIPTION
## 概要

CI で発生していた shellcheck / actionlint エラーを修正します。

## 修正内容

### 1. `""$GITHUB_OUTPUT""` → `"$GITHUB_OUTPUT"` の修正 (7 箇所)

以下の 4 ファイルで、`$GITHUB_OUTPUT` が二重クォートで囲まれていたため、リダイレクト先が環境変数として展開されず、`"$GITHUB_OUTPUT"` というリテラル文字列のファイル名にリダイレクトされていました。

| ファイル | 修正箇所数 |
|---|---|
| `.github/workflows/reusable-add-reviewer.yml` | 1 箇所 |
| `.github/workflows/reusable-docker.yml` | 3 箇所 |
| `.github/workflows/reusable-nodejs-ci.yml` | 4 箇所 |
| `.github/workflows/reusable-nodejs-ci-pnpm.yml` | 2 箇所 |

### 2. `reusable-docker.yml` の parameter expansion 修正 (SC2295 / SC2086)

```diff
- REPO="${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}"
- ZIP_FILENAME=${REPO}_...
- ZIP_PATH=$(pwd)/output/${ZIP_FILENAME}
- zip -r ${ZIP_PATH} ./*
+ REPO="${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}/"}"
+ ZIP_FILENAME="${REPO}_..."
+ ZIP_PATH="$(pwd)/output/${ZIP_FILENAME}"
+ zip -r "${ZIP_PATH}" ./*
```

- SC2295: `${...#pattern}` のパターン内で変数展開する場合も内側をクォートする必要がある
- SC2086: グロブ・単語分割防止のため変数をダブルクォートで囲む

### 3. `reusable-nodejs-ci.yml` の複数リダイレクト修正 (SC2129)

```diff
- echo "compile=$compile" >> "$GITHUB_OUTPUT"
- echo "build=$build" >> "$GITHUB_OUTPUT"
- ...
+ {
+   echo "compile=$compile"
+   echo "build=$build"
+   ...
+ } >> "$GITHUB_OUTPUT"
```

SC2129: 個別リダイレクトを `{ ... } >> file` にまとめることを推奨する指摘に対応。

## 影響範囲

再利用可能ワークフローのリポジトリのため、このリポジトリを参照している他 org のワークフローにも影響します。修正により、各ワークフローのステップ出力が正しく `$GITHUB_OUTPUT` ファイルに書き込まれるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)