### PR TITLE
fix: Dockerfile の pnpm 関連設定を修正

### DIFF
--- a/dockerfiles/node-app-pnpm.Dockerfile
+++ b/dockerfiles/node-app-pnpm.Dockerfile
@@ -15,7 +15,7 @@ RUN apk update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 

--- a/dockerfiles/node-app-pnpm.Dockerfile
+++ b/dockerfiles/node-app-pnpm.Dockerfile
@@ -11,7 +11,6 @@ RUN apk update && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -26,8 +25,7 @@ RUN chmod +x entrypoint.sh
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 

--- a/dockerfiles/puppeteer-pnpm.Dockerfile
+++ b/dockerfiles/puppeteer-pnpm.Dockerfile
@@ -14,7 +14,6 @@ RUN apk upgrade --no-cache --available && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -26,8 +25,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 COPY entrypoint.sh ./
 RUN chmod +x ./entrypoint.sh

--- a/dockerfiles/puppeteer-pnpm.Dockerfile
+++ b/dockerfiles/puppeteer-pnpm.Dockerfile
@@ -18,7 +18,7 @@ RUN apk upgrade --no-cache --available && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 

--- a/dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile
+++ b/dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile
@@ -14,7 +14,6 @@ RUN apk upgrade --no-cache --available && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -26,8 +25,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 COPY entrypoint.sh ./
 RUN chmod +x ./entrypoint.sh

--- a/dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile
+++ b/dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile
@@ -18,7 +18,7 @@ RUN apk upgrade --no-cache --available && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 


### PR DESCRIPTION
## 概要

Dockerfile テンプレートの pnpm 関連設定を 2 点修正します。

## 変更内容

### 1. `pnpm approve-builds` の削除

pnpm v10 以降は `pnpm-workspace.yaml` の `allowBuilds` で事前に許可することで、`pnpm install` 実行時に自動的にスクリプトが実行されます。各プロジェクトの `pnpm-workspace.yaml` に `allowBuilds` を設定することで対応します。

### 2. `pnpm fetch` 前に `package.json` もコピー

`pnpm fetch` 実行時に `package.json` が存在しないと、corepack が `packageManager` フィールドを読めず最新の pnpm (v11) をダウンロードしてしまいます。pnpm v11 は `node:sqlite` を使用しますが Node.js v20 には存在しないため失敗します。

```diff
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
```

## 対象ファイル

- `dockerfiles/node-app-pnpm.Dockerfile`
- `dockerfiles/puppeteer-pnpm.Dockerfile`
- `dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile`

関連: book000/book000#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)