### PR TITLE
fix: pnpm fetch 前に package.json もコピーして corepack のバージョン解決を修正

### DIFF
--- a/dockerfiles/node-app-pnpm.Dockerfile
+++ b/dockerfiles/node-app-pnpm.Dockerfile
@@ -16,7 +16,7 @@ RUN apk update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 

--- a/dockerfiles/puppeteer-pnpm.Dockerfile
+++ b/dockerfiles/puppeteer-pnpm.Dockerfile
@@ -19,7 +19,7 @@ RUN apk upgrade --no-cache --available && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 

--- a/dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile
+++ b/dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile
@@ -19,7 +19,7 @@ RUN apk upgrade --no-cache --available && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 


### PR DESCRIPTION
## 概要

`pnpm fetch` 実行時に `package.json` が存在しないと corepack が `packageManager` フィールドを読めず、最新の pnpm をダウンロードしてしまう問題を修正します。

## 問題

```dockerfile
COPY pnpm-lock.yaml ./
RUN pnpm fetch   # ← package.json がないので corepack が pnpm@latest (v11) をダウンロード
                 #   pnpm v11 は node:sqlite を使用するが Node.js v20 には存在しない → ❌
```

## 修正

```dockerfile
COPY pnpm-lock.yaml package.json ./
RUN pnpm fetch   # ← package.json の packageManager フィールドから pnpm@10.x を使用 → ✅
```

## 対象ファイル

- `dockerfiles/node-app-pnpm.Dockerfile`
- `dockerfiles/puppeteer-pnpm.Dockerfile`
- `dockerfiles/puppeteer-virtual-display-pnpm.Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)