### PR TITLE
fix: shellcheck SC2015 の警告を修正

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -32,10 +32,10 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add README.md && \
-          git commit -m "feat: Update README.md" && \
-          git push || \
-            true
+          git add README.md
+          if git commit -m "feat: Update README.md"; then
+            git push
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## 概要

`generate-readme.yml` の `A && B || C` パターンを `if-then-fi` に書き換えて actionlint/shellcheck の SC2015 警告を解消します。

## 変更内容

```diff
-          git add README.md && \
-          git commit -m "feat: Update README.md" && \
-          git push || \
-            true
+          git add README.md
+          if git commit -m "feat: Update README.md"; then
+            git push
+          fi
```

## 動作

- `git commit` が成功した場合（変更あり）: `git push` を実行
- `git commit` が失敗した場合（変更なし）: `git push` をスキップしてステップ成功
- `git push` が失敗した場合: ステップ失敗（実際のエラーとして検知）

🤖 Generated with [Claude Code](https://claude.com/claude-code)