### PR TITLE
fix: deploy key を使った SSH push で branch protection を回避

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
@@ -27,14 +30,51 @@ jobs:
         run: |
           node scripts/generate-readme.js
 
+      - name: Setup SSH for push
+        if: github.event_name == 'push'
+        env:
+          PUSH_DEPLOY_KEY: ${{ secrets.PUSH_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+
+          echo "$PUSH_DEPLOY_KEY" > ~/.ssh/deploy_ed25519
+          chmod 600 ~/.ssh/deploy_ed25519
+
+          # GitHub の公式 SSH ホスト鍵を固定値で書き込む（ssh-keyscan による MITM リスクを回避）
+          cat > ~/.ssh/known_hosts << 'KNOWNHOSTS'
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+          github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+          KNOWNHOSTS
+
+          cat > ~/.ssh/config << 'SSHCONFIG'
+          Host github.com
+            IdentityFile ~/.ssh/deploy_ed25519
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            BatchMode yes
+          SSHCONFIG
+
+          # SSH 接続テストで Deploy Key 認証を事前確認
+          ssh_output=$(ssh -T git@github.com 2>&1 || true)
+          echo "$ssh_output"
+          if [[ "$ssh_output" != *"successfully authenticated"* ]]; then
+            echo "SSH authentication failed"
+            exit 1
+          fi
+
+          # Deploy Key で Ruleset をバイパスするため SSH URL に変更
+          git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+
       - name: Commit and push
         if: github.event_name == 'push'
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add README.md
-          if git commit -m "feat: Update README.md"; then
-            git push
+          if git commit -m "feat: Update README.md [skip ci]"; then
+            git pull --rebase origin master
+            git push origin HEAD:master
           fi
 
       - name: Upload artifact

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Install dependencies
         run: |
@@ -73,8 +74,8 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add README.md
           if git commit -m "feat: Update README.md [skip ci]"; then
-            git pull --rebase origin master
-            git push origin HEAD:master
+            git pull --rebase origin "$GITHUB_REF_NAME"
+            git push origin "HEAD:$GITHUB_REF_NAME"
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
## 概要

`GITHUB_TOKEN` による HTTPS push では Ruleset の branch protection をバイパスできないため、deploy key を使った SSH push に変更します。

## 変更内容

- `actions/checkout` に `persist-credentials: false` を追加（GITHUB_TOKEN クレデンシャルを無効化）
- `Setup SSH for push` ステップを追加
  - `PUSH_DEPLOY_KEY` シークレットから SSH 秘密鍵を設定
  - GitHub 公式ホスト鍵を `known_hosts` に固定書き込み（MITM 回避）
  - SSH 接続テストで認証を事前確認
  - git remote を SSH URL に変更
- `git push` を `git push origin HEAD:master` に変更
- コミットメッセージに `[skip ci]` を追加（README 更新で CI が再トリガーされないよう）

## 事前設定済み

- Deploy Key 登録済み（book000/templates, write access, ID: 154610696）
- Ruleset bypass actor に DeployKey を設定済み
- シークレット `PUSH_DEPLOY_KEY` 設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)