### PR TITLE
feat: Renovate に Node.js グルーピング設定を追加

### DIFF
--- a/renovate/base.json
+++ b/renovate/base.json
@@ -44,8 +44,7 @@
       "matchPackageNames": ["fastify", "fastify-raw-body", "@fastify/**"]
     },
     {
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": ["^@book000/"],
+      "matchPackageNames": ["!/^@book000//"],
       "stabilityDays": 3
     },
     {

--- a/renovate/base.json
+++ b/renovate/base.json
@@ -47,6 +47,16 @@
       "matchPackagePatterns": ["*"],
       "excludePackagePatterns": ["^@book000/"],
       "stabilityDays": 3
+    },
+    {
+      "groupName": "Node.js",
+      "matchManagers": ["node-version"],
+      "matchPackageNames": ["node"]
+    },
+    {
+      "groupName": "Node.js",
+      "matchManagers": ["devcontainer"],
+      "matchPackageNames": ["mcr.microsoft.com/devcontainers/typescript-node"]
     }
   ]
 }


### PR DESCRIPTION
## 変更内容

Renovate の `packageRules` に Node.js グルーピング設定を追加します。

### 追加設定

```json
{
  "groupName": "Node.js",
  "matchManagers": ["node-version"],
  "matchPackageNames": ["node"]
},
{
  "groupName": "Node.js",
  "matchManagers": ["devcontainer"],
  "matchPackageNames": ["mcr.microsoft.com/devcontainers/typescript-node"]
}
```

### 効果

Node.js の新しい LTS バージョンが出たとき、`.node-version` と `devcontainer.json` の両方の更新が同一 PR にまとまるようになります。

ref: book000/book000#118
