### PR TITLE
feat: GitHub Actions の digest pin を有効化

### DIFF
--- a/renovate/base.json
+++ b/renovate/base.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disableRateLimiting"],
+  "extends": [
+    "config:base",
+    ":disableRateLimiting",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "automerge": true,


### PR DESCRIPTION
## 概要

GitHub 公式のセキュリティ推奨(Actions はメジャータグではなくフルコミット SHA で固定する)に合わせるため、共有 Renovate プリセット (`renovate/base.json`) に `helpers:pinGitHubActionDigestsToSemver` を追加します。

## 背景

- 参照: [GitHub Docs - Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- タグは可変(メンテナのアカウント乗っ取り等で書き換え可能)なため、フルコミット SHA 固定がサプライチェーン攻撃対策として推奨されている。
- 現状、本プリセットを extends する book000 organization の各リポジトリでは Actions がメジャーバージョンタグ(例: `actions/checkout@v6`)で参照されており、公式推奨と乖離していた。

## 変更内容

- `renovate/base.json` の `extends` に `helpers:pinGitHubActionDigestsToSemver` を追加。
- これにより、本プリセットを利用する全リポジトリで Actions 参照が `actions/checkout@<sha> # v6.0.1` のような形式へ Renovate が自動的に更新する PR を出すようになる。

## 影響範囲

- `renovate/base.json` を extends している全リポジトリ(`renovate/public.json` / `renovate/private.json` 経由含む)。
- 既存の `automerge: true` 設定により、digest pin PR も自動マージ対象になる点に留意。

## 既知の問題(本 PR とは無関係)

- `renovate-config-validator`(renovate@latest)でローカル検証した際、`renovate/base.json` の既存 `packageRules[3]`(`matchPackagePatterns: ["*"]`)がバリデーションエラーになることを確認した。これは master ブランチの時点で既に発生している既存の問題であり、本 PR の変更とは無関係。別途対応が必要。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T42vamwfnFphu9hL3J55ME