### PR TITLE
feat: reusable-docker に allow-unsafe-pr-checkout 入力を追加

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -31,6 +31,15 @@ on:
         description: Next custom version (Not included prefix)
         type: string
         default: ""
+      allow-unsafe-pr-checkout:
+        description: >-
+          Allow checking out a fork pull request's head SHA from a
+          pull_request_target-triggered workflow. Only set this to true
+          after the caller workflow has gated it behind a manual review
+          step (e.g. an Environment approval), since this defeats
+          actions/checkout's default pwn-request protection.
+        type: boolean
+        default: false
     outputs:
       version:
         description: Next version
@@ -91,6 +100,7 @@ jobs:
           # マージされていない時には github.event.pull_request.head.sha を使い、マージされた時にはgithub.base_refを使う
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
 
       - name: 🏷️ Bump version and push tag
         id: tag-version
@@ -184,6 +194,7 @@ jobs:
         with:
           # マージされていない時には github.event.pull_request.head.sha を使い、マージされた時にはgithub.base_refを使う
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -371,6 +382,7 @@ jobs:
         with:
           # マージされていない時には github.event.pull_request.head.sha を使い、マージされた時にはgithub.base_refを使う
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
 
       - name: 📂 Check exists .node-version
         id: check-node-version-file


### PR DESCRIPTION
## 概要

`reusable-docker.yml` の `workflow_call` に `allow-unsafe-pr-checkout`（真偽値、デフォルト `false`）を追加し、3 箇所の `actions/checkout` ステップに `allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}` を渡すようにしました。

## 背景

`pull_request_target` トリガーのワークフローから `actions/checkout` でフォーク PR の head SHA をチェックアウトすると、`actions/checkout` のセキュリティ機構により拒否されます（"Refusing to check out fork pull request code from a 'pull_request_target' workflow"）。

呼び出し元（例: `book000/mitm-packet-sniffer` の `docker.yml`）では、フォーク PR に対して GitHub Environment（`fork-pr-build`）による人的承認をすでに必須にしています。この承認ゲートを通過した PR に限り、`allow-unsafe-pr-checkout: true` を渡すことで、承認済みフォーク PR のビルド検証を通常のチェックアウトフローで行えるようにします。

## 変更内容

- `workflow_call.inputs` に `allow-unsafe-pr-checkout`（型: boolean、デフォルト: false）を追加
- `calc-version` / `build` / `upload-package` の各ジョブの `actions/checkout` ステップに `allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}` を追加

## 互換性

デフォルト値が `false` のため、既存の呼び出し元（`allow-unsafe-pr-checkout` を指定しない呼び出し元）の挙動に変更はありません。

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` で YAML 構文を確認
- `docker run --rm rhysd/actionlint:latest` でワークフロー全体の静的解析を実施（エラーなし）
- 既存の `test-reusable-workflows.yml` の `test-docker` ジョブは本入力を指定しないため、デフォルト値 `false` のまま影響を受けない

## 注意事項（セキュリティ）

`allow-unsafe-pr-checkout: true` は `actions/checkout` の pwn request 対策を無効化する設定です。呼び出し元が Environment 承認などの人的レビューを経た場合にのみ true を渡すよう、`description` に明記しています。