### PR TITLE
fix: book000/templates 参照の digest 固定を無効化し既存の固定を戻す

### DIFF
--- a/renovate/base.json
+++ b/renovate/base.json
@@ -34,6 +34,10 @@
   ],
   "packageRules": [
     {
+      "matchDepNames": ["book000/templates"],
+      "pinDigests": false
+    },
+    {
       "matchPackageNames": ["node"],
       "matchManagers": ["dockerfile"],
       "enabled": false

--- a/workflows/actionlint.yml
+++ b/workflows/actionlint.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   actionlint:
     name: Actionlint with reviewdog
-    uses: book000/templates/.github/workflows/reusable-actionlint.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-actionlint.yml@master

--- a/workflows/add-reviewer.yml
+++ b/workflows/add-reviewer.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   add-reviewer:
     name: Add reviewer
-    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@master

--- a/workflows/docker.yml
+++ b/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
     name: Docker CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    uses: book000/templates/.github/workflows/reusable-docker.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [
@@ -87,6 +87,7 @@ jobs:
         ]
       # registry: registry.hub.docker.com # default: ghcr.io
       # platforms: linux/amd64 # default: linux/amd64,linux/arm64
+      allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/hadolint-ci.yml
+++ b/workflows/hadolint-ci.yml
@@ -14,4 +14,4 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@master

--- a/workflows/maven-ci.yml
+++ b/workflows/maven-ci.yml
@@ -78,7 +78,7 @@ jobs:
     name: Maven CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    uses: book000/templates/.github/workflows/reusable-maven.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-maven.yml@master
     # with:
     #    java-version: 17 # default: 17
     #    jdk-distribution: adopt # default: adopt

--- a/workflows/nodejs-ci-pnpm.yml
+++ b/workflows/nodejs-ci-pnpm.yml
@@ -76,4 +76,4 @@ jobs:
     name: Node CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success'
-    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@master

--- a/workflows/nodejs-ci.yml
+++ b/workflows/nodejs-ci.yml
@@ -76,4 +76,4 @@ jobs:
     name: Node CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success'
-    uses: book000/templates/.github/workflows/reusable-nodejs-ci.yml@1d3c112ba6b8e5ac13c24a8e3892f92b98ea35ac # master
+    uses: book000/templates/.github/workflows/reusable-nodejs-ci.yml@master


### PR DESCRIPTION
## 概要

`renovate/base.json` の `helpers:pinGitHubActionDigestsToSemver` プリセットにより、book000/templates 自身が持つ reusable workflow への自己参照(`book000/templates/.github/workflows/reusable-*.yml@master`)まで digest 固定されてしまっていました。

これは book000/book000#124 のロールアウト対応(各リポジトリの `@<digest>` → `@master` 変更)にも影響しており、対応後のリポジトリで Renovate が走ると `@master` が即座に digest へ再固定されてしまうことを確認しています(例: book000/kindle-booklog#2350 マージ直後の #2351)。

## 変更内容

- `renovate/base.json` の `packageRules` に `matchDepNames: ["book000/templates"]` に対して `pinDigests: false` を設定するルールを追加(今後の新規 digest 固定を防止)
- 既に digest 固定されてしまっている7ファイル(`workflows/actionlint.yml`, `add-reviewer.yml`, `maven-ci.yml`, `nodejs-ci.yml`, `hadolint-ci.yml`, `docker.yml`, `nodejs-ci-pnpm.yml`)の `uses:` 行を `@master`(digest なし)に戻す
- `docker.yml` は `reusable-docker.yml` を呼んでいるため、`allow-unsafe-pr-checkout`(book000/templates#430)も併せて設定

## 検証

- `json.load` で `renovate/base.json` の構文を確認
- `yaml.safe_load` で変更した全 workflow ファイルの構文を確認

## スコープ外

他リポジトリで既に digest 固定済みの book000/templates 参照を自動的に master へ戻すことは本 PR のスコープ外です。それらは book000/book000#124 のロールアウト対応(および Renovate による今後の自動追従)で個別に解消されます。

## 関連

- book000/templates#432 (本 Issue。Spec/Plan 作成後、実装 PR 未作成のまま Completed としてクローズされていたための再対応)
- book000/book000#124 (ロールアウト対応の親 Issue)