### PR TITLE
fix: reusable-maven.ymlにallow-unsafe-pr-checkoutを追加する

### DIFF
--- a/.github/workflows/reusable-maven.yml
+++ b/.github/workflows/reusable-maven.yml
@@ -78,6 +78,9 @@ jobs:
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
           fetch-depth: 0
           allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
+          # allow-unsafe-pr-checkout 有効時(=フォークPRをcheckoutする場合)は
+          # GITHUB_TOKEN を git config に残さないことでpwn-requestのリスクを下げる
+          persist-credentials: ${{ !inputs.allow-unsafe-pr-checkout }}
 
       - name: Bump version and push tag
         id: tag-version
@@ -104,6 +107,9 @@ jobs:
           # マージされていない時には github.event.pull_request.head.sha を使い、マージされた時にはgithub.base_refを使う
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
           allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
+          # allow-unsafe-pr-checkout 有効時(=フォークPRをcheckoutする場合)は
+          # GITHUB_TOKEN を git config に残さないことでpwn-requestのリスクを下げる
+          persist-credentials: ${{ !inputs.allow-unsafe-pr-checkout }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0

--- a/.github/workflows/reusable-maven.yml
+++ b/.github/workflows/reusable-maven.yml
@@ -31,6 +31,15 @@ on:
         description: Working directory containing pom.xml
         type: string
         default: .
+      allow-unsafe-pr-checkout:
+        description: >-
+          Allow checking out a fork pull request's head SHA from a
+          pull_request_target-triggered workflow. Only set this to true
+          after the caller workflow has gated it behind a manual review
+          step (e.g. an Environment approval), since this defeats
+          actions/checkout's default pwn-request protection.
+        type: boolean
+        default: false
     outputs:
       version:
         description: Next version
@@ -68,6 +77,7 @@ jobs:
           # マージされていない時には github.event.pull_request.head.sha を使い、マージされた時にはgithub.base_refを使う
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
 
       - name: Bump version and push tag
         id: tag-version
@@ -93,6 +103,7 @@ jobs:
         with:
           # マージされていない時には github.event.pull_request.head.sha を使い、マージされた時にはgithub.base_refを使う
           ref: ${{ inputs.is-merged == true && github.base_ref || inputs.pr-head-sha }}
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0


### PR DESCRIPTION
## 概要

`reusable-docker.yml` には `allow-unsafe-pr-checkout` 入力があり、Environment承認(`fork-pr-build`)を経てフォークPRのheadをチェックアウトできる仕組みがあるが、`reusable-maven.yml` には同等の仕組みがなかった。

book000/SystemdLogTracker#67 (book000/book000#124 のロールアウト対応PR)で、`pull_request_target` トリガーの `calc-version`/`build` ジョブが `actions/checkout` の pwn-request 防御に阻まれて常に失敗することが判明した。

## 変更内容

- `allow-unsafe-pr-checkout` 入力を追加(デフォルト `false`)
- `calc-version` / `build` 各ジョブの checkout ステップに `allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}` を設定

`reusable-docker.yml` の実装パターンに準拠。

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` でYAML構文を確認

## 関連

- book000/book000#124
- book000/SystemdLogTracker#67 (本問題の発覚元)