### PR TITLE
feat: typescript-eslint の TypeScript 7 対応を検知する定期チェックを追加

### DIFF
--- a/.github/workflows/check-typescript-eslint-ts7-support.yml
+++ b/.github/workflows/check-typescript-eslint-ts7-support.yml
@@ -63,13 +63,10 @@ jobs:
         if: steps.check.outputs.supports_ts7 == 'true' && steps.existing.outputs.count == '0'
         env:
           GH_TOKEN: ${{ github.token }}
+          RANGE: ${{ steps.check.outputs.range }}
         run: |
+          BODY=$(printf 'typescript-eslint の `peerDependencies.typescript` が `%s` に更新され、TypeScript 7 系を許容するようになった可能性があります。\n\nrenovate/base.json に暫定で入れている typescript のメジャー更新ブロックルールを解除できるか確認してください。\n\n- 検知元: このリポジトリの `check-typescript-eslint-ts7-support` ワークフロー\n- 確認事項: 実際に `typescript@7.x` + 最新の `typescript-eslint` で ESLint が正常動作するか、対象リポジトリの1つで動作確認してから解除すること' "$RANGE")
           gh issue create --repo "${{ github.repository }}" \
             --title "typescript-eslint が TypeScript 7 に対応した可能性 — Renovate のブロックルール解除を検討" \
             --assignee book000 \
-            --body "typescript-eslint の \`peerDependencies.typescript\` が \`${{ steps.check.outputs.range }}\` に更新され、TypeScript 7 系を許容するようになった可能性があります。
-
-renovate/base.json に暫定で入れている typescript のメジャー更新ブロックルールを解除できるか確認してください。
-
-- 検知元: このリポジトリの \`check-typescript-eslint-ts7-support\` ワークフロー
-- 確認事項: 実際に \`typescript@7.x\` + 最新の \`typescript-eslint\` で ESLint が正常動作するか、対象リポジトリの1つで動作確認してから解除すること"
+            --body "$BODY"

--- a/.github/workflows/check-typescript-eslint-ts7-support.yml
+++ b/.github/workflows/check-typescript-eslint-ts7-support.yml
@@ -1,0 +1,75 @@
+name: Check typescript-eslint TypeScript 7 support
+
+# 目的: typescript-eslint が TypeScript 7 系に対応したかを定期的に検知する。
+#
+# 背景: TypeScript 7 (Go ネイティブコンパイラ) は tsc の内部 API (ts.Extension.Cjs 等) を
+# 提供していないため、typescript-eslint@8.63.0 系はこれに依存する起動時コードで
+# クラッシュする。typescript-eslint 側も peerDependencies で typescript を
+# <6.1.0 までに制限しており、対応は TS7 の新API公開待ち
+# (https://github.com/typescript-eslint/typescript-eslint/issues/10940)。
+#
+# renovate/base.json では暫定的に typescript のメジャー更新をブロックしているため、
+# 対応が入ったタイミングに気づけるよう、npm 上の typescript-eslint の
+# peerDependencies.typescript が TypeScript 7 系を許容するようになったかを
+# 週次でチェックし、対応が確認できた場合のみ Issue を起票する。
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # 毎週月曜 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check typescript-eslint peer range
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # 対応検知時に Issue を起票するため
+
+    steps:
+      - name: Install semver
+        run: npm install --global semver
+
+      - name: Check typescript-eslint peerDependencies.typescript range
+        id: check
+        run: |
+          RANGE=$(npm view typescript-eslint peerDependencies.typescript)
+          if [ -z "$RANGE" ]; then
+            echo "::error::typescript-eslint の peerDependencies.typescript を取得できませんでした"
+            exit 1
+          fi
+
+          SUPPORTS_TS7=$(node -e "
+            const semver = require('$(npm root -g)/semver');
+            console.log(semver.intersects(process.argv[1], '>=7.0.0', { includePrerelease: true }));
+          " "$RANGE")
+
+          echo "range=$RANGE" >> "$GITHUB_OUTPUT"
+          echo "supports_ts7=$SUPPORTS_TS7" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing tracking issue
+        if: steps.check.outputs.supports_ts7 == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COUNT=$(gh issue list --repo "${{ github.repository }}" \
+            --search "TypeScript 7 in:title" --state open --json number --jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Create tracking issue
+        if: steps.check.outputs.supports_ts7 == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "${{ github.repository }}" \
+            --title "typescript-eslint が TypeScript 7 に対応した可能性 — Renovate のブロックルール解除を検討" \
+            --assignee book000 \
+            --body "typescript-eslint の \`peerDependencies.typescript\` が \`${{ steps.check.outputs.range }}\` に更新され、TypeScript 7 系を許容するようになった可能性があります。
+
+renovate/base.json に暫定で入れている typescript のメジャー更新ブロックルールを解除できるか確認してください。
+
+- 検知元: このリポジトリの \`check-typescript-eslint-ts7-support\` ワークフロー
+- 確認事項: 実際に \`typescript@7.x\` + 最新の \`typescript-eslint\` で ESLint が正常動作するか、対象リポジトリの1つで動作確認してから解除すること"


### PR DESCRIPTION
## 背景

TypeScript 7 (Go ネイティブコンパイラ) は tsc の内部API (`ts.Extension.Cjs` 等) をまだ提供しておらず、typescript-eslint@8.63.0 系はこれに依存する起動時コードでクラッシュする。実際に `tomacheese/vrcx-web-server#1046` 等、org 内の Renovate が作成した "update dependency typescript to v7" PR が軒並み CI 失敗している。

typescript-eslint 側の peerDependencies も `typescript@>=4.8.4 <6.1.0` に制限されており、対応は TS7 の新API公開待ち([typescript-eslint/typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940))。

## この PR の内容

renovate/base.json 側で typescript のメジャー更新を暫定ブロックする対応は別途予定しているが、それだけでは typescript-eslint 側の対応完了に気づく手段がない。GitHub Issue の Watch は見落としが発生するため不採用とし、代わりに npm 上の `typescript-eslint` の `peerDependencies.typescript` を**週次**でチェックし、TypeScript 7 系を許容するようになったことを検知した場合のみ本リポジトリに Issue を起票するワークフローを追加した。

## 検討した代替案と不採用理由

- **typescript-eslint の追跡 Issue を Watch するだけ**: 通知の見落としが発生するため不採用。
- **検知後に renovate/base.json のブロックルールを自動で外す PR まで作る**: 誤検知時に自動でブロックが解除されるリスクがあるため、まずは Issue 起票のみに留め、解除は人間の判断とする。

## 前提・不確実性

- 判定は `typescript-eslint` メタパッケージの `peerDependencies.typescript` の範囲を `semver.intersects()` で `>=7.0.0` と交差するかで行っている。実際に TS7 で動作するかまでは保証しないため、Issue 本文で「対象リポジトリの1つで動作確認してから解除すること」を明記した。
- cron は毎週月曜 00:00 UTC。

🤖 Generated with [Claude Code](https://claude.com/claude-code)