### PR TITLE
fix: typescript-eslint が TS7 未対応のため typescript のメジャー更新を暫定ブロック

### DIFF
--- a/renovate/base.json
+++ b/renovate/base.json
@@ -58,8 +58,7 @@
       "enabled": false
     },
     {
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": ["^@book000/"],
+      "matchPackageNames": ["!/^@book000\\//"],
       "stabilityDays": 3
     }
   ]

--- a/renovate/base.json
+++ b/renovate/base.json
@@ -52,6 +52,12 @@
       "matchPackageNames": ["fastify", "fastify-raw-body", "@fastify/**"]
     },
     {
+      "description": "TypeScript 7 は tsc の内部API (ts.Extension.Cjs 等) をまだ提供しておらず、typescript-eslint@8.63.0 系がこれに依存する起動時コードでクラッシュするため、typescript のメジャー更新を暫定的にブロックする。typescript-eslint 側の対応状況は check-typescript-eslint-ts7-support ワークフローで検知するので、対応が確認できたらこのルールを削除すること (typescript-eslint/typescript-eslint#10940)",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchPackagePatterns": ["*"],
       "excludePackagePatterns": ["^@book000/"],
       "stabilityDays": 3


### PR DESCRIPTION
## 背景

TypeScript 7 (Go ネイティブコンパイラ) は tsc の内部API (`ts.Extension.Cjs` 等) をまだ提供しておらず、typescript-eslint@8.63.0 系はこれに依存する起動時コードでクラッシュする。実際に `book000`/`tomacheese`/`jaoafa` 各オーガニゼーションで Renovate が作成した "update dependency typescript to v7" PR が40件以上、軒並み CI 失敗している(例: `tomacheese/vrcx-web-server#1046`)。

typescript-eslint 側の peerDependencies も `typescript@>=4.8.4 <6.1.0` に制限されており、対応は TS7 の新API公開待ち([typescript-eslint/typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940))。

## この PR の内容

`renovate/base.json` の `packageRules` に、`typescript` のメジャー更新(現状は 7系)を `enabled: false` でブロックするルールを追加した。これにより Renovate が今後 typescript v7 系への更新 PR を作成しなくなる。

対応状況は #446 で追加した `check-typescript-eslint-ts7-support` ワークフローが週次でチェックし、typescript-eslint が TS7 に対応したことを検知したら Issue を起票する。対応が確認できたら、このルールを削除すること。

## 検討した代替案と不採用理由

- **dependencyDashboardApproval で可視化**: 本リポジトリの共通設定で `dependencyDashboard: false` としており、これだけのために有効化すると他の抑制済み更新も一覧化されてノイズが増えるため不採用。
- **stabilityDays を伸ばすだけ**: 根本的に typescript-eslint 側が対応しない限り無限に失敗し続けるため、PR自体を作らないようにするのが妥当と判断。

## 影響範囲

このプリセット (`github>book000/templates//renovate/base-public` 経由) を `extends` している全リポジトリに適用される。既存の "update dependency typescript to v7" PR(約40件超、`book000`/`tomacheese`/`jaoafa` 各オーガニゼーション)は本 PR マージ後も自動では閉じられないため、別途 `renovate-pr-doctor` 等で後始末が必要。

## 前提・不確実性

- `matchUpdateTypes: ["major"]` で判定しているため、将来 TS8 等さらに次のメジャーが出た場合も同様にブロックされる。typescript-eslint 対応後にこのルール自体を見直す(削除 or バージョン条件化)必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)