### PR TITLE
feat: Reusable Workflow (Node CI / Docker) にステップ並列実行を導入する

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -210,16 +210,16 @@ jobs:
       - name: 📝 package.json update version
         run: |
           find . -type d -name node_modules -prune -o -type f -name package.json -exec sed -r -i "1,/version/s/\"version\": \".+\"/\"version\": \"${{ needs.calc-version.outputs.version }}\"/" {} \;
-          git diff
+          git diff -- '**/package.json'
         background: true
 
       - name: 📝 Create application version file
         run: |
           echo -n "${{ needs.calc-version.outputs.version }}" > .app-version
-          git diff
+          git diff -- .app-version
         background: true
 
-      - name: 👀 Wait for version file updates
+      - name: ⏳ Wait for parallel steps
         wait-all: true
 
       - name: 🏷️ Set tag suffix value

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -211,11 +211,16 @@ jobs:
         run: |
           find . -type d -name node_modules -prune -o -type f -name package.json -exec sed -r -i "1,/version/s/\"version\": \".+\"/\"version\": \"${{ needs.calc-version.outputs.version }}\"/" {} \;
           git diff
+        background: true
 
       - name: 📝 Create application version file
         run: |
           echo -n "${{ needs.calc-version.outputs.version }}" > .app-version
           git diff
+        background: true
+
+      - name: 👀 Wait for version file updates
+        wait-all: true
 
       - name: 🏷️ Set tag suffix value
         id: tag

--- a/.github/workflows/reusable-nodejs-ci-pnpm.yml
+++ b/.github/workflows/reusable-nodejs-ci-pnpm.yml
@@ -172,7 +172,7 @@ jobs:
         run: npx depcheck
         background: true
 
-      - name: 👀 Wait for linter/tests/depcheck
+      - name: ⏳ Wait for parallel steps
         wait-all: true
 
       - name: 🎁 Run package

--- a/.github/workflows/reusable-nodejs-ci-pnpm.yml
+++ b/.github/workflows/reusable-nodejs-ci-pnpm.yml
@@ -158,6 +158,22 @@ jobs:
         if: steps.package-json.outputs.lint == 'true' && steps.package-json.outputs.disabled-lint == 'false'
         working-directory: ${{ matrix.directory }}
         run: pnpm run lint
+        background: true
+
+      - name: 🧪 Run tests
+        if: steps.package-json.outputs.test == 'true' && steps.package-json.outputs.disabled-test == 'false'
+        working-directory: ${{ matrix.directory }}
+        run: pnpm run test
+        background: true
+
+      - name: ☑️ Check Dependencies
+        if: steps.package-json.outputs.disabled-depcheck == 'false'
+        working-directory: ${{ matrix.directory }}
+        run: npx depcheck
+        background: true
+
+      - name: 👀 Wait for linter/tests/depcheck
+        wait-all: true
 
       - name: 🎁 Run package
         if: steps.package-json.outputs.package == 'true' && steps.package-json.outputs.disabled-package == 'false'
@@ -179,16 +195,6 @@ jobs:
         run: |
           pnpm run build
           pnpm run generate
-
-      - name: 🧪 Run tests
-        if: steps.package-json.outputs.test == 'true' && steps.package-json.outputs.disabled-test == 'false'
-        working-directory: ${{ matrix.directory }}
-        run: pnpm run test
-
-      - name: ☑️ Check Dependencies
-        if: steps.package-json.outputs.disabled-depcheck == 'false'
-        working-directory: ${{ matrix.directory }}
-        run: npx depcheck
 
       - name: Check exists dist directory
         id: check-dist

--- a/.github/workflows/reusable-nodejs-ci.yml
+++ b/.github/workflows/reusable-nodejs-ci.yml
@@ -135,6 +135,22 @@ jobs:
         if: steps.package-json.outputs.lint == 'true' && steps.package-json.outputs.disabled-lint == 'false'
         working-directory: ${{ matrix.directory }}
         run: yarn lint
+        background: true
+
+      - name: 🧪 Run tests
+        if: steps.package-json.outputs.test == 'true' && steps.package-json.outputs.disabled-test == 'false'
+        working-directory: ${{ matrix.directory }}
+        run: yarn test
+        background: true
+
+      - name: ☑️ Check Dependencies
+        if: steps.package-json.outputs.disabled-depcheck == 'false'
+        working-directory: ${{ matrix.directory }}
+        run: npx depcheck
+        background: true
+
+      - name: 👀 Wait for linter/tests/depcheck
+        wait-all: true
 
       - name: 🎁 Run package
         if: steps.package-json.outputs.package == 'true' && steps.package-json.outputs.disabled-package == 'false'
@@ -156,16 +172,6 @@ jobs:
         run: |
           yarn build
           yarn generate
-
-      - name: 🧪 Run tests
-        if: steps.package-json.outputs.test == 'true' && steps.package-json.outputs.disabled-test == 'false'
-        working-directory: ${{ matrix.directory }}
-        run: yarn test
-
-      - name: ☑️ Check Dependencies
-        if: steps.package-json.outputs.disabled-depcheck == 'false'
-        working-directory: ${{ matrix.directory }}
-        run: npx depcheck
 
       - name: Check exists dist directory
         id: check-dist

--- a/.github/workflows/reusable-nodejs-ci.yml
+++ b/.github/workflows/reusable-nodejs-ci.yml
@@ -149,7 +149,7 @@ jobs:
         run: npx depcheck
         background: true
 
-      - name: 👀 Wait for linter/tests/depcheck
+      - name: ⏳ Wait for parallel steps
         wait-all: true
 
       - name: 🎁 Run package


### PR DESCRIPTION
## 概要

GitHub Actions の新機能「ステップの並列実行」(`background:` / `wait-all:`、2026-06-25 リリース) を、以下の Reusable Workflow に試験導入する。

1. `reusable-nodejs-ci-pnpm.yml` / `reusable-nodejs-ci.yml` の `node-ci` ジョブ: `👀 Run linter` / `🧪 Run tests` / `☑️ Check Dependencies` の3ステップを並列実行にする。
2. `reusable-docker.yml` の `build` ジョブ: `📝 package.json update version` / `📝 Create application version file` の2ステップを並列実行にする。

いずれも `background: true` を並列化対象ステップに付与し、直後に `wait-all: true` の同期待ちステップを追加する構文を採用した。`🎁 Run package` / `🏃 Run compile` / `🏗️ Run build & generate (Nuxt.js)` は、後続の artifact アップロードが生成物に依存するため対象外とし、既存の逐次実行順序を維持している。

## 判断記録

### 構文選定(background/wait-all を採用)

GitHub 公式ドキュメントには本 PR 作成時点で `background`/`wait`/`wait-all`/`cancel`/`parallel` の具体的な YAML 構文サンプルが見当たらなかった。changelog の記述に最も近い形として、各ステップへの `background: true` 付与 + 末尾の `wait-all: true` ステップという構成(候補A)を採用した。代替として検討した「`parallel:` ブロックで囲む」構成(候補B)は不採用とした。

理由: `./actionlint`(インストール済みバージョン、および WebFetch で確認した最新リリースまで)はどちらの候補も同一クラスのエラー(`unexpected key`)で拒否し、これは候補固有の構文誤りではなく、actionlint 側がこの新機能自体にまだ対応していないツール側の制約であると判断した。実際の妥当性確認は、マージ後の実 CI 実行(後述の `/pr-health-monitor` によるモニタリング)に委ねる。

### deep-review で指摘された「ステップ並び替えによる依存破壊リスク」について

`🧪 Run tests` / `☑️ Check Dependencies` は、変更前は `🎁 Run package` / `🏃 Run compile` / `🏗️ Run build & generate` の後に実行されていたが、本 PR では並列化のためこれらより前に実行されるよう並び替えている。deep-review の複数の独立したレビュー観点(correctness / performance / 呼び出し元互換性)から「呼び出し元の test/depcheck スクリプトがビルド生成物に依存している場合、新規の CI 失敗を招くリスクがある」との指摘があった(信頼度スコア75)。

これについて実リポジトリを調査した結果、リスクは限定的と判断した:
- `depcheck` はソースコードと `package.json` を静的解析するツールであり、ビルド生成物には一切依存しない(`depcheck --help` で確認)。
- 実際の主要な呼び出し元リポジトリ(`book000/node-utils`, `book000/twitter-auto-spam-crawler`, `book000/create-ts` 等)の `jest`/`vitest` 設定を確認したところ、いずれも `ts-jest`/vitest のネイティブ TypeScript 変換で `src/**/*.test.ts` を直接実行しており、`dist/` などのビルド生成物を参照する設定は存在しなかった。
- 変更前の並び順は、`git log` 調査の結果、依存関係を意図した設計ではなく、機能追加が時系列で追記された結果だったことを確認した(depcheck 追加時のコミットメッセージにも順序に関する言及なし)。

以上の一次調査に基づき、並び替えを維持しコード変更は行わないと判断した。ただし呼び出し元 package.json のスクリプト内容次第では例外的なケースが存在しうるため、マージ後に代表的な呼び出し元リポジトリで CI 結果(成功/失敗判定・artifact 内容)が変わらないことを `/pr-health-monitor` で確認する。

### deep-review でのその他の対応

- 待機ステップ名 `👀 Wait for linter/tests/depcheck` / `👀 Wait for version file updates` は、`👀` が本リポジトリの絵文字対応表で「Lint / status check」を意味するため、同期待ちステップへの転用は同一ファイル内で3つ目の異なる意味を持たせることになり不整合、かつ待機対象ステップ名をステップ名にハードコードすると将来の構成変更時に名前が陳腐化するリスクがあった。`⏳ Wait for parallel steps` に統一して修正済み。
- `reusable-docker.yml` の2つの並列ステップ内の `git diff` は、並列実行時に互いの未コミット差分がログに混在しうる曖昧性があったため、対象ファイルを明示指定する形に修正済み。
- `wait-all: true` が background ステップの失敗を正しくジョブ失敗として伝播するかどうかは、GitHub 公式ドキュメントに記載がなく現時点では未確認。actionlint もこの構文を検証できないため、構文誤りを静的に検出する手段が現状ない。この点はマージ後の実 CI 実行で確認する。
- 2 vCPU ランナー上で lint/test/depcheck を並列実行することによるリソース競合(新規のテストタイムアウト等)についても、マージ後の CI 結果観察で確認する。

## 前提条件・仮定・不確実性

- 新機能の GA/beta 区分、同時実行数の上限、artifact/cache 書き込み競合に関する公式ガイダンスは、GitHub 公式ドキュメント上で一次確認が取れていない。
- 本 Reusable Workflow は book000 org 内で約20リポジトリから継承されており、影響範囲が大きい。段階的ロールアウト(個別リポジトリへの限定適用)は行わず、直接 `master` にマージしたうえでマージ後の CI 結果観察により検証する方針とした。

## 受け入れ基準

- 対象ジョブの CI 実行時間が変更前後で比較できること。
- 各並列ステップのログが Actions UI 上で個別に確認できること。
- 既存の呼び出し元リポジトリ(代表的な複数リポジトリ)で、変更前後の CI 結果(成功/失敗判定、artifact 内容)が同一であること。

## 関連リンク

Closes #449

Spec: https://github.com/book000/templates/issues/449#issuecomment-4989395284
Plan: https://github.com/book000/templates/issues/449#issuecomment-4989457448
