### PR TITLE
fix: pnpm を v11.12.0 から v11.11.0 に戻す

### DIFF
--- a/test-scenarios/nodejs-pnpm-ignored-build-scripts/package.json
+++ b/test-scenarios/nodejs-pnpm-ignored-build-scripts/package.json
@@ -2,7 +2,7 @@
   "name": "test-nodejs-pnpm-ignored-build-scripts",
   "version": "1.0.0",
   "description": "pnpm v11 の Ignored build scripts 検出テスト用プロジェクト",
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.11.0",
   "dependencies": {
     "esbuild": "0.28.1"
   }

--- a/test-scenarios/nodejs-pnpm/package.json
+++ b/test-scenarios/nodejs-pnpm/package.json
@@ -14,5 +14,5 @@
   "devDependencies": {},
   "author": "test",
   "license": "MIT",
-  "packageManager": "pnpm@11.12.0"
+  "packageManager": "pnpm@11.11.0"
 }


### PR DESCRIPTION
## 概要

`test-scenarios/nodejs-pnpm/package.json` と `test-scenarios/nodejs-pnpm-ignored-build-scripts/package.json` の `packageManager` を `pnpm@11.12.0` から `pnpm@11.11.0` に戻す。

## 判断記録

### 何が起きていたか

`pnpm/action-setup` の `Setup pnpm` ステップで、pnpm 自身の self-installer(バージョン切り替え時に pnpm パッケージ内蔵のロックファイルを解析して再インストールする内部処理)が以下のエラーで例外を起こし、CI が headless install の時点で失敗していた。

```
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
    at createFullPkgId ... at lockfileToDepGraph ... at headlessInstall ...
##[error]Something went wrong, self-installer exits with code 1
```

この障害は `reusable-nodejs-ci-pnpm.yml` / `reusable-docker.yml` などの本 PR での変更内容(#449 のステップ並列実行導入)より前段の `Setup pnpm` ステップで発生しており、それらの変更とは無関係。

### 原因

Renovate PR #448 (`chore(deps): update pnpm to v11.12.0`) が `packageManager` を `pnpm@11.12.0` に更新したことが原因。この PR は **マージ時点で `Test reusable-nodejs-ci-pnpm` 系のジョブの CI が既に失敗していた** にもかかわらずマージされていた(`gh pr view 448 --json statusCheckRollup` で確認)。

### 検討した代替案

- **pnpm の最新版(執筆時点 v11.13.1)に上げる**: self-installer の不具合が修正されている可能性はあるが、実際に修正されたかどうかは pnpm 側の changelog で一次確認できておらず、本 PR 作成時点では検証していない。不採用(下記「前提条件・仮定・不確実性」参照)。
- **`pnpm/action-setup` 側で `version` 入力を明示指定し `packageManager` フィールドを無視させる**: 恒久対策としては検討の余地があるが、今回は影響範囲を最小化するため `packageManager` の値のみを戻す最小修正とした。

### 採用理由

直前の Renovate PR #445 (`chore(deps): update pnpm to v11.11.0`) は該当ジョブの CI が成功していたことを確認済み。動作実績のあるバージョンに戻すのが最も確実な修正と判断した。

## 前提条件・仮定・不確実性

- pnpm v11.12.0 の self-installer 不具合が pnpm 側の既知のリグレッションかどうかは、pnpm 本体の Issue/changelog では一次確認していない(このリポジトリの CI ログからの推測)。
- Renovate は今後も `pnpm@11.12.0` (またはそれ以降)への更新 PR を再度作成しうる。pnpm 側で修正されるまでは、当該 Renovate PR のマージ前に CI 結果を必ず確認する運用上の注意が必要。
- `dockerfiles/tests/*-pnpm/package.json` 系(`pnpm@10.2.1` 固定、integrity ハッシュ付き)は今回の Renovate PR #448 の対象外であり、本修正の対象にも含めていない。

## 関連リンク

Ref: #449 (作業中に発覧した既存の別障害)
Renovate PR: #448 (原因), #445 (直前の動作確認済みバージョン)