### PR TITLE
fix: test-reusable-workflows を常時実行にし必須ステータスチェックの検出対象にする

### DIFF
--- a/.github/workflows/test-reusable-workflows.yml
+++ b/.github/workflows/test-reusable-workflows.yml
@@ -9,10 +9,6 @@ on:
     branches:
       - main
       - master
-    paths:
-      - ".github/workflows/reusable-*.yml"
-      - "test-scenarios/**"
-      - ".github/workflows/test-reusable-workflows.yml"
   workflow_dispatch:
 
 jobs:
@@ -144,8 +140,13 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
   # Summary job to check all tests passed
+  # ジョブ名の末尾に " Finished" を含める: book000/sync-repo-settings の
+  # detect_status_checks() が必須ステータスチェックを自動検出する際、
+  # prefer_finished_jobs: true の設定により "finished" を含むジョブ名を
+  # 優先して選択する。これにより、全テストジョブの成否を集約するこの
+  # ジョブだけが必須チェックとして登録されるようにする。
   test-summary:
-    name: Test Summary
+    name: Test Summary Finished
     runs-on: ubuntu-latest
     if: always()
     needs:


### PR DESCRIPTION
## 概要

`test-reusable-workflows.yml`(Reusable Workflow のテストスイート)が `pull_request` トリガーに `paths:` フィルタを持っていたため、`book000/sync-repo-settings` の必須ステータスチェック自動検出ロジック(`detect_status_checks()`)から除外されていた。その結果、このワークフロー内のテストジョブ(pnpm セルフインストーラーのテストなど)が失敗していても、必須チェックとして扱われず自動マージをブロックできない状態だった(PR #448 で実際に発生)。

本 PR では、このワークフローを常時実行化した上で、全テストジョブの成否を集約する `test-summary` ジョブだけが必須チェックとして検出されるようにする。

## 変更内容

- `pull_request` トリガーの `paths:` フィルタを削除し、全 PR で常時実行されるようにした
- `test-summary` ジョブの表示名を `Test Summary` → `Test Summary Finished` に変更した
  - `book000/sync-repo-settings` の `detect_status_checks()` は `prefer_finished_jobs: true` の設定により、ジョブ名が `finished` を含むものを優先して必須チェックとして選択する
  - これにより、他の個別テストジョブではなく、全テストの成否を集約するこのジョブだけが必須チェックとして登録可能になる

## 判断記録

### 判断内容の要約

- `paths:` フィルタを削除して常時実行化する(`pull_request_target` の追加ではなく)
- `test-summary` ジョブ名に `Finished` を含めて `prefer_finished_jobs` の自動検出に乗せる

### 検討した代替案

1. **`pull_request_target` を追加して常時実行化する** → このリポジトリの GitHub Actions コーディングルールで「特権トークン/シークレットが必要な場合を除き避けるべき」とされており、本ワークフローはテスト実行のみで特権シークレットを必要としないため不採用。`paths:` フィルタ削除の方がシンプルかつルールに沿う。
2. **`book000/sync-repo-settings` の `config.json` 側で `book000/templates` 専用の必須チェックを手動設定する** → 対象リポジトリ側の設定変更が不要な本 PR のアプローチの方が影響範囲が小さく、`sync-repo-settings` 側の全社共通ロジックを変更しないため不採用。
3. **現状維持** → PR #448 のように必須チェックに含まれないテストの失敗を見逃したまま自動マージされる問題が再発するため不採用。

### 前提条件・仮定・不確実性

- `book000/sync-repo-settings` 側の次回適用(cron/手動実行)まで、`book000/templates` のルールセットへの必須チェック追加は反映されない。反映タイミングはこの PR の管理下にない。
- `paths:` フィルタ削除により、本ワークフローに無関係な変更(例: README のみの PR)でも毎回テストスイート全体が実行されるようになり、CI 実行時間・コストが増加する。GitHub の必須ステータスチェックの仕様上、全 PR で確実に実行されないと必須チェックとして機能しないため、この増加は必須チェック化とのトレードオフとして受容する。
- `test-summary` ジョブ名の変更は表示名のみで、ジョブ ID (`test-summary`) や `needs:` の参照先には影響しない。
- 他の book000 org 内リポジトリの必須チェック検出ロジックには影響しない(本 PR は `book000/templates` のワークフローファイルのみを変更)。

## 動作確認

- `./actionlint .github/workflows/test-reusable-workflows.yml` : エラーなし